### PR TITLE
Ignore packets for other VRID instances - references iamacarpet/uvrrpd#2

### DIFF
--- a/vrrp_net.c
+++ b/vrrp_net.c
@@ -413,6 +413,13 @@ int vrrp_net_recv(struct vrrp_net *vnet, const struct vrrp *vrrp)
 		return INVALID;
 	}
 
+    /* check if VRID is the same as the current instance */
+	if (vrrpkt->vrid != vrrp->vrid) {
+		log_info("vrid %d :: Invalid pkt - Invalid VRID %d",
+			 vrrp->vrid, vrrpkt->vrid);
+		return OTHERVRID;
+	}
+
 	/* verify VRRP checksum */
 	int chksum = vrrpkt->chksum;	/* save checksum */
 	if (vnet->adv_checksum(vnet, vrrpkt, &vnet->__pkt.s_ipx,
@@ -424,13 +431,6 @@ int vrrp_net_recv(struct vrrp_net *vnet, const struct vrrp *vrrp)
 	}
 	/* restore checksum */
 	vrrpkt->chksum = chksum;
-
-	/* check if VRID is the same as the current instance */
-	if (vrrpkt->vrid != vrrp->vrid) {
-		log_info("vrid %d :: Invalid pkt - Invalid VRID %d",
-			 vrrp->vrid, vrrpkt->vrid);
-		return OTHERVRID;
-	}
 
 	/* local router is the IP address owner
 	 * (Priority equals 255) 

--- a/vrrp_net.c
+++ b/vrrp_net.c
@@ -308,12 +308,17 @@ int vrrp_net_listen(struct vrrp_net *vnet, struct vrrp *vrrp)
 		log_debug("vrid %d :: VRRP pkt received", vrrp->vrid);
 
 		/* check if received is valid or not */
-		if (vrrp_net_recv(vnet, vrrp) > 0)
+		int ret = vrrp_net_recv(vnet, vrrp);
+		if (ret > 0)
 			return PKT;
 		else {
-			log_error("vrid %d :: %s", vrrp->vrid,
-				  "Received an invalid packet");
-			return INVALID;
+			if (ret > -49){
+				log_error("vrid %d :: %s", vrrp->vrid,
+					"Received an invalid packet");
+				return INVALID;
+			} else {
+				return OTHERVRID;
+			}
 		}
 	}
 	else {	/* Signal or pselect error */
@@ -424,7 +429,7 @@ int vrrp_net_recv(struct vrrp_net *vnet, const struct vrrp *vrrp)
 	if (vrrpkt->vrid != vrrp->vrid) {
 		log_info("vrid %d :: Invalid pkt - Invalid VRID %d",
 			 vrrp->vrid, vrrpkt->vrid);
-		return INVALID;
+		return OTHERVRID;
 	}
 
 	/* local router is the IP address owner

--- a/vrrp_net.h
+++ b/vrrp_net.h
@@ -143,7 +143,8 @@ enum vrrp_ret {
 	INVALID = -1,
 	PKT,	/* valid packet received */
 	SIGNAL,	/* signal catch */
-	TIMER	/* timer expired */
+	TIMER,	/* timer expired */
+	OTHERVRID = -50 /* Belongs to other VRID */
 };
 
 /*

--- a/vrrp_state.c
+++ b/vrrp_state.c
@@ -150,6 +150,9 @@ int vrrp_state_backup(struct vrrp *vrrp, struct vrrp_net *vnet)
 
 		break;
 
+	case OTHERVRID:
+		break;
+
 	default:
 		log_error("vrid %d :: %s r:%d", vrrp->vrid, "unknown event",
 			  event);
@@ -256,6 +259,9 @@ int vrrp_state_master(struct vrrp *vrrp, struct vrrp_net *vnet)
 	case INVALID:
 		log_warning("vrid %d :: invalid event", vrrp->vrid);
 		break;
+
+	case OTHERVRID:
+                break;
 
 	default:
 		log_error("vrid %d :: %s r:%d", vrrp->vrid, "unknown event",


### PR DESCRIPTION
Hello guys,

Can I have your advice on this patch?

I made it to fix an issue where multiple instances with their own VRID would cause a massive amount of log entries stating "invalid packet".

Debugging showed it was because it was getting packets for other VRIDs, so I made this to ignore them without logging.

It doesn't seem to affect functionality and didn't without the patch either - still works OK!

Great work on this tool!

Thanks,
IAmACarpet
