### PR TITLE
Only use IPv6 sysctls when $family = 6

### DIFF
--- a/vrrp_switch.sh
+++ b/vrrp_switch.sh
@@ -42,9 +42,11 @@ case "$state" in
 
         for ip in $ips; do
             ip -$family addr add $ip dev $interface 
-	    sysctl -w net/ipv6/conf/$interface/autoconf=0
-	    sysctl -w net/ipv6/conf/$interface/accept_ra=0
-	    sysctl -w net/ipv6/conf/$interface/forwarding=1
+            if [ $family = 6 ]; then
+	        sysctl -w net/ipv6/conf/$interface/autoconf=0
+	        sysctl -w net/ipv6/conf/$interface/accept_ra=0
+	        sysctl -w net/ipv6/conf/$interface/forwarding=1
+            fi
         done
         ip link set dev $interface up
         


### PR DESCRIPTION
Arnaud,

Here is a minor fix to avoid errors such as:

```
sysctl: cannot stat /proc/sys/net/ipv6/conf/eth0_33/autoconf: No such file or directory
```

Feel free to merge it, if it makes sense.
